### PR TITLE
fix the argparser bool type issue

### DIFF
--- a/lib/astunparse/__main__.py
+++ b/lib/astunparse/__main__.py
@@ -35,7 +35,7 @@ def main(args):
     )
     parser.add_argument(
         '--dump',
-        type='bool',
+        type=bool,
         help="Show a pretty-printed AST instead of the source"
     )
 


### PR DESCRIPTION
This will raise an error:

$> PYTHONPATH=lib python -m astunparse
...
    raise ValueError('%r is not callable' % (type_func,))
ValueError: 'bool' is not callable

The patch fixes that:
$> PYTHONPATH=lib python -m astunparse
usage: astunparse [-h] [--dump DUMP] target [target ...]
astunparse: error: too few arguments