### PR TITLE
#18: Fix formatted string with only one value, like `f{foo}`

### DIFF
--- a/lib/astunparse/unparser.py
+++ b/lib/astunparse/unparser.py
@@ -446,7 +446,7 @@ class Unparser:
 
     def _FormattedValue(self, t):
         # FormattedValue(expr value, int? conversion, expr? format_spec)
-        self.write("{")
+        self.write("f'''{")
         self.dispatch(t.value)
         if t.conversion is not None and t.conversion != -1:
             self.write("!")
@@ -458,17 +458,14 @@ class Unparser:
                 self.write(t.format_spec.s)
             else:
                 self.dispatch(t.format_spec)
-        self.write("}")
+        self.write("}'''")
 
     def _JoinedStr(self, t):
         # JoinedStr(expr* values)
-        self.write("f'''")
+        self.write("(")
         for value in t.values:
-            if isinstance(value, ast.Str):
-                self.write(value.s)
-            else:
-                self.dispatch(value)
-        self.write("'''")
+            self.dispatch(value)
+        self.write(")")
 
     def _Name(self, t):
         self.write(t.id)

--- a/lib/astunparse/unparser.py
+++ b/lib/astunparse/unparser.py
@@ -454,7 +454,15 @@ class Unparser:
         if t.format_spec is not None:
             self.write(":")
             if isinstance(t.format_spec, ast.Str):
+                # It's ast.Str in 3.6.0
                 self.write(t.format_spec.s)
+            elif isinstance(t.format_spec, ast.JoinedStr):
+                # It's ast.JoinedStr in 3.6.1+
+                for value in t.format_spec.values:
+                    if isinstance(value, ast.Str):
+                        self.write(value.s)
+                    else:
+                        self.dispatch(value)
             else:
                 self.dispatch(t.format_spec)
         self.write("}")

--- a/tests/common.py
+++ b/tests/common.py
@@ -288,8 +288,12 @@ class AstunparseCommonTestCase:
     def test_bytes(self):
         self.check_roundtrip("b'123'")
 
+    @unittest.skipIf(sys.version_info < (3, 6), "Not supported < 3.6")
     def test_formatted_value(self):
-        self.check_roundtrip('f"{key}"')
+        self.check_roundtrip('f"{value}"')
+        self.check_roundtrip('f"{value!s}"')
+        self.check_roundtrip('f"{value:4}"')
+        self.check_roundtrip('f"{value!s:4}"')
 
     @unittest.skipIf(sys.version_info < (3, 6), "Not supported < 3.6")
     def test_joined_str(self):

--- a/tests/common.py
+++ b/tests/common.py
@@ -288,6 +288,9 @@ class AstunparseCommonTestCase:
     def test_bytes(self):
         self.check_roundtrip("b'123'")
 
+    def test_formatted_value(self):
+        self.check_roundtrip('f"{key}"')
+
     @unittest.skipIf(sys.version_info < (3, 6), "Not supported < 3.6")
     def test_joined_str(self):
         self.check_roundtrip('f"{key}={value!s}"')


### PR DESCRIPTION
Before:
```python
In [1]: import ast
In [2]: from astunparse import unparse
In [3]: print(unparse(ast.parse('f"{foo}"')))

{foo}
```

After:
```python
In [1]: import ast
In [2]: from astunparse import unparse
In [3]: print(unparse(ast.parse('f"{foo}"')))

f'''{foo}'''
```