### PR TITLE
#17: Add support of dict unpacking

### DIFF
--- a/lib/astunparse/unparser.py
+++ b/lib/astunparse/unparser.py
@@ -561,9 +561,13 @@ class Unparser:
         self.write("{")
         def write_pair(pair):
             (k, v) = pair
-            self.dispatch(k)
-            self.write(": ")
-            self.dispatch(v)
+            if k is None:
+                self.write('**')
+                self.dispatch(v)
+            else:
+                self.dispatch(k)
+                self.write(": ")
+                self.dispatch(v)
             self.write(",")
         self._indent +=1
         self.fill("")

--- a/tests/common.py
+++ b/tests/common.py
@@ -328,6 +328,11 @@ class AstunparseCommonTestCase:
         self.check_roundtrip("{x: x*x for x in range(10)}")
 
     @unittest.skipIf(sys.version_info < (3, 6), "Not supported < 3.6")
+    def test_dict_with_unpacking(self):
+        self.check_roundtrip("{**x}")
+        self.check_roundtrip("{a: b, **x}")
+
+    @unittest.skipIf(sys.version_info < (3, 6), "Not supported < 3.6")
     def test_async_comp_and_gen_in_async_function(self):
         self.check_roundtrip(async_comprehensions_and_generators)
 


### PR DESCRIPTION
It was failing before changes, like described in #17.
After changes:
```python
In [1]: import ast
In [2]: from astunparse import unparse
In [3]: print(unparse(ast.parse('{a:b, **c}')))
{
    a: b,
    **c,
}
```