### PR TITLE
Do a better job at handling very complex f-strings.

### DIFF
--- a/lib/astunparse/unparser.py
+++ b/lib/astunparse/unparser.py
@@ -447,7 +447,20 @@ class Unparser:
         self.write("f")
         string = StringIO()
         self._fstring_JoinedStr(t, string.write)
-        self.write(repr(string.getvalue()))
+        # Deviation from `unparse.py`: Try to find an unused quote.
+        # This change is made to handle _very_ complex f-strings.
+        v = string.getvalue()
+        if '\n' in v or '\r' in v:
+            quote_types = ["'''", '"""']
+        else:
+            quote_types = ["'", '"', '"""', "'''"]
+        for quote_type in quote_types:
+            if quote_type not in v:
+                v = "{quote_type}{v}{quote_type}".format(quote_type=quote_type, v=v)
+                break
+        else:
+            v = repr(v)
+        self.write(v)
 
     def _FormattedValue(self, t):
         # FormattedValue(expr value, int? conversion, expr? format_spec)

--- a/tests/common.py
+++ b/tests/common.py
@@ -139,6 +139,10 @@ a_repr = """\
 `{}`
 """
 
+complex_f_string = '''\
+f\'\'\'-{f"""*{f"+{f'.{x}.'}+"}*"""}-\'\'\'
+'''
+
 async_function_def = """\
 async def f():
     suite1
@@ -316,6 +320,10 @@ class AstunparseCommonTestCase:
     @unittest.skipUnless(six.PY2, "Only for Python 2")
     def test_repr(self):
         self.check_roundtrip(a_repr)
+
+    @unittest.skipUnless(sys.version_info[:2] >= (3, 6), "Only for Python 3.6 or greater")
+    def test_complex_f_string(self):
+        self.check_roundtrip(complex_f_string)
 
     @unittest.skipUnless(six.PY3, "Only for Python 3")
     def test_annotations(self):


### PR DESCRIPTION
This is a change from the code copied from the Python code base, in
that, instead of naively repr'ing the "JoinedStr", we're checking the
string for quote types present.

There's gonna be a slow-down for very large strings, but I'm assuming
that it's not gonna be an issue in real-world code.

Fixes #29 