### PR TITLE
Include tests in sdist and wheel

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,4 +5,3 @@ include LICENSE
 include README.rst
 include requirements.txt
 include test_requirements.txt
-recursive-include tests *.py

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 import sys
 import os
 import re
-from setuptools import setup, find_packages
+from setuptools import setup
 
 readme = open('README.rst').read()
 history = open('HISTORY.rst').read().replace('.. :changelog:', '')
@@ -33,8 +33,9 @@ setup(
     maintainer='Simon Percivall',
     maintainer_email='percivall@gmail.com',
     url='https://github.com/simonpercivall/astunparse',
-    packages=find_packages('lib'),
-    package_dir={'': 'lib'},
+    packages=['astunparse', 'astunparse.tests'],
+    package_dir={'astunparse': 'lib/astunparse',
+                 'astunparse.tests': 'tests'},
     include_package_data=True,
     install_requires=read_reqs('requirements.txt'),
     license="BSD",

--- a/tests/test_dump.py
+++ b/tests/test_dump.py
@@ -7,7 +7,8 @@ else:
     import unittest
 
 import astunparse
-from tests.common import AstunparseCommonTestCase
+from .common import AstunparseCommonTestCase
+
 
 class DumpTestCase(AstunparseCommonTestCase, unittest.TestCase):
 

--- a/tests/test_unparse.py
+++ b/tests/test_unparse.py
@@ -6,7 +6,8 @@ else:
     import unittest
 
 import astunparse
-from tests.common import AstunparseCommonTestCase
+from .common import AstunparseCommonTestCase
+
 
 class UnparseTestCase(AstunparseCommonTestCase, unittest.TestCase):
 


### PR DESCRIPTION
We define the `tests` directory as a subpackage of astunparse; this hack allows us to easily include the tests in both the `sdist` and `bdist_wheel`.

We can then simply call `python -m unittest astunparse.tests.test_unparse` after installation (e.g., via `pip install astunparse`), and the test suite will run.