### PR TITLE
Python 3.8 Constant: Support for nonexistent and other "kind" fields

### DIFF
--- a/lib/astunparse/unparser.py
+++ b/lib/astunparse/unparser.py
@@ -548,8 +548,8 @@ class Unparser:
         elif value is Ellipsis: # instead of `...` for Py2 compatibility
             self.write("...")
         else:
-            if t.kind == "u":
-                self.write("u")
+            if hasattr(t, "kind") and t.kind is not None:
+                self.write(t.kind)
             self._write_constant(t.value)
 
     def _Num(self, t):


### PR DESCRIPTION
As `kind` is an optional field, it may not necessarily exist in valid AST (e.g., for numeric constants). This PR both supports this case, as well as other string kinds, such as `'b'` (see https://github.com/python/cpython/commit/10f8ce66884cd7fee2372b8dae08ca8132091574)