### PR TITLE
Feature generalize unparser a little

### DIFF
--- a/lib/astunparse/unparser.py
+++ b/lib/astunparse/unparser.py
@@ -403,7 +403,8 @@ class Unparser:
         self.leave()
         # collapse nested ifs into equivalent elifs.
         while (t.orelse and len(t.orelse) == 1 and
-               isinstance(t.orelse[0], ast.If)):
+               (isinstance(t.orelse[0], ast.If) or
+                getattr(t.orelse[0], '_class', '') == 'If')):
             t = t.orelse[0]
             self.fill("elif ")
             self.dispatch(t.test)

--- a/lib/astunparse/unparser.py
+++ b/lib/astunparse/unparser.py
@@ -493,13 +493,17 @@ class Unparser:
         # FormattedValue(expr value, int? conversion, expr? format_spec)
         self.write("f")
         string = StringIO()
-        self._fstring_JoinedStr(t, string.write)
+        self._fstring_JoinedStr1(t, string.write)
         self.write(repr(string.getvalue()))
+
+    def _fstring_JoinedStr1(self, value, write):
+        cname = getattr(value, '_class', type(value).__name__)
+        meth = getattr(self, "_fstring_" + cname)
+        meth(value, write)
 
     def _fstring_JoinedStr(self, t, write):
         for value in t.values:
-            meth = getattr(self, "_fstring_" + type(value).__name__)
-            meth(value, write)
+            self._fstring_JoinedStr1(value, write)
 
     def _fstring_Str(self, t, write):
         value = t.s.replace("{", "{{").replace("}", "}}")
@@ -524,7 +528,8 @@ class Unparser:
             write("!{conversion}".format(conversion=conversion))
         if t.format_spec:
             write(":")
-            meth = getattr(self, "_fstring_" + type(t.format_spec).__name__)
+            cname = getattr(t.format_spec, '_class', type(t.format_spec).__name__)
+            meth = getattr(self, "_fstring_" + cname)
             meth(t.format_spec, write)
         write("}")
 

--- a/lib/astunparse/unparser.py
+++ b/lib/astunparse/unparser.py
@@ -68,8 +68,12 @@ class Unparser:
             for t in tree:
                 self.dispatch(t)
             return
-        meth = getattr(self, "_"+tree.__class__.__name__)
-        meth(tree, **(kw if meth.__name__ in ["_Tuple"] else {}))
+        cname = getattr(tree, '_class', tree.__class__.__name__)
+        meth = getattr(self, "_"+cname, None)
+        if meth:
+            meth(tree, **(kw if meth.__name__ in ["_Tuple"] else {}))
+        else:
+            self.write('"<' + cname + '>"')
 
 
     ############### Unparsing methods ######################

--- a/tests/common.py
+++ b/tests/common.py
@@ -293,6 +293,18 @@ class AstunparseCommonTestCase:
     def test_bytes(self):
         self.check_roundtrip("b'123'")
 
+    def test_index(self):
+        self.check_roundtrip("r[0]")
+        self.check_roundtrip("r[0:5]")
+        self.check_roundtrip("r[0:5:2]")
+        self.check_roundtrip("r[1::2]")
+
+    def test_index2(self):
+        self.check_roundtrip("r[0,i]")
+        self.check_roundtrip("r[:,0:5]")
+        self.check_roundtrip("r[i:1:-1, 2]")
+        self.check_roundtrip("r[i:1:-1, :]")
+
     @unittest.skipIf(sys.version_info < (3, 6), "Not supported < 3.6")
     def test_formatted_value(self):
         self.check_roundtrip('f"{value}"')


### PR DESCRIPTION
Hi, this is a suggestion: Could we make the unparser a little bit more generic maybe:

 - allow .op to be the plain string, like "+", "*" in BinOp, UnaryOps, etc.
 - detect the node type not only by the actual type but also by some special attribute

The idea is that we can use a more generic tree structure that is easier to work with.

https://github.com/aiandit/astunparse

If you look at the other branches in our fork, you can see where this is heading, we can have ASTs with a clone method and load/save to JSON and XML, for example. If you like, we would contribute all of it to the project, also because it's obviously inspired by your code a lot, but this pull request is the set of changes that we would need to make it work with astunparse, if we would alternatively put that additional stuff into a separate package.

Tested with py27 and py39.

What do you think? Thanks in advance for considering. 

Best regards